### PR TITLE
Allow env vars to work in FE Docker image

### DIFF
--- a/react/40-index-envsubst.sh
+++ b/react/40-index-envsubst.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# vim:sw=4:ts=4:et
+
+set -e
+
+entrypoint_log() {
+    if [ -z "${NGINX_ENTRYPOINT_QUIET_LOGS:-}" ]; then
+        echo "$@"
+    fi
+}
+
+cd /usr/share/nginx/html
+envsubst < index.html > index_env.html
+entrypoint_log "Wrote enbsubst result to index_env.html"
+mv index_env.html index.html
+entrypoint_log "Moved index_env.html to index.html"

--- a/react/Dockerfile
+++ b/react/Dockerfile
@@ -10,7 +10,9 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 RUN yarn build
 
-FROM base AS server
-RUN yarn global add serve
-COPY --from=build /app/build ./
-CMD serve -s build
+FROM nginx:1.23.2-alpine AS server
+WORKDIR /usr/share/nginx/html
+# default.conf
+COPY default.conf.template /etc/nginx/templates/default.conf.template
+COPY 40-index-envsubst.sh /docker-entrypoint.d/
+COPY --from=build /app/build .

--- a/react/default.conf.template
+++ b/react/default.conf.template
@@ -1,0 +1,10 @@
+server {
+    listen       $PORT;
+    listen  [::]:$PORT;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html;
+    }
+}
+# vim: ft=nginx

--- a/react/default.conf.template
+++ b/react/default.conf.template
@@ -5,6 +5,8 @@ server {
     location / {
         root   /usr/share/nginx/html;
         index  index.html;
+        # Allow for stateful URLs
+        try_files $uri /index.html;
     }
 }
 # vim: ft=nginx

--- a/react/public/index.html
+++ b/react/public/index.html
@@ -9,6 +9,11 @@
       name="description"
       content="Web site created using create-react-app"
     />
+    <script>
+        window.ENV = {
+            REACT_APP_API_HOST: "$REACT_APP_API_HOST",
+        }
+    </script>
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a

--- a/react/src/env.ts
+++ b/react/src/env.ts
@@ -1,1 +1,27 @@
-export const API_HOST = process.env.REACT_APP_API_HOST
+interface EnvVars {
+  [key: string]: string
+}
+
+// @ts-ignore this value is set in public/index.html
+const INJECTED_ENV_DATA: EnvVars = window.ENV || {}
+const BUILDTIME_ENV_DATA = process.env || {}
+
+// Attempt to follow the same naming conventions and restrictions imposed by
+// CRA (i.e. the two magic values + anything starting with REACT_APP). This
+// won't stop you from setting inappriate values, but it slims the surface area
+const SANITIZED_INJECTED_ENV_DATA = Object.keys(INJECTED_ENV_DATA)
+  .filter(key => key === 'NODE_ENV' || key === 'PUBLIC_URL' || key.startsWith('REACT_APP_'))
+  .reduce((obj, key) => {
+    const val = INJECTED_ENV_DATA[key]
+    // Remove anything that didn't get substituted or is blank
+    if (val !== '$' + key && val !== '') {
+      obj[key] = val
+    }
+    return obj
+  }, {} as EnvVars)
+
+const combined = { ...BUILDTIME_ENV_DATA, ...SANITIZED_INJECTED_ENV_DATA }
+
+// Actual config follows
+
+export const API_HOST = combined.REACT_APP_API_HOST


### PR DESCRIPTION
Add another startup script (auto-detected by the nginx image) to perform `envsubst` on the contents of `index.html`. Squash a bunch of stuff together in the env reading file to combine the sources for the static prod build and the local implementation.